### PR TITLE
style(linting): Simple linting with clippy + fmt

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,67 +3,67 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 pub struct Commit {
-  /// Sets the 'type' component of the commit (optional; otherwise interactive prompt)
-  #[structopt(short, long)]
-  pub ty: Option<String>,
+    /// Sets the 'type' component of the commit (optional; otherwise interactive prompt)
+    #[structopt(short, long)]
+    pub ty: Option<String>,
 
-  /// Sets the 'scope' component of the commit (optional; otherwise interactive prompt)
-  #[structopt(short, long)]
-  pub scope: Option<String>,
+    /// Sets the 'scope' component of the commit (optional; otherwise interactive prompt)
+    #[structopt(short, long)]
+    pub scope: Option<String>,
 
-  /// Sets the main message component of the commit (optional; otherwise interactive prompt)
-  #[structopt(short, long)]
-  pub message: Option<String>,
+    /// Sets the main message component of the commit (optional; otherwise interactive prompt)
+    #[structopt(short, long)]
+    pub message: Option<String>,
 
-  #[structopt(short, long)]
-  pub all: bool,
+    #[structopt(short, long)]
+    pub all: bool,
 
-  /// Arguments which will be passed to 'git commit'.
-  /// Pass a '--' argument before the git args to disable special parsing.
-  #[structopt(short, long)]
-  pub git_args: Vec<String>,
+    /// Arguments which will be passed to 'git commit'.
+    /// Pass a '--' argument before the git args to disable special parsing.
+    #[structopt(short, long)]
+    pub git_args: Vec<String>,
 }
 
 #[derive(StructOpt)]
 pub struct Log {
-  /// Filter by 'type' e.g. 'feat'
-  #[structopt(short, long)]
-  pub ty: Option<String>,
+    /// Filter by 'type' e.g. 'feat'
+    #[structopt(short, long)]
+    pub ty: Option<String>,
 
-  /// Filter by 'scope' e.g. 'client'
-  #[structopt(short, long)]
-  pub scope: Option<String>,
+    /// Filter by 'scope' e.g. 'client'
+    #[structopt(short, long)]
+    pub scope: Option<String>,
 
-  /// Number of commits to display.
-  #[structopt(short, long)]
-  pub num: Option<usize>,
+    /// Number of commits to display.
+    #[structopt(short, long)]
+    pub num: Option<usize>,
 
-  /// Only useful when filing bug reports for glint.
-  #[structopt(short, long)]
-  pub debug: bool,
+    /// Only useful when filing bug reports for glint.
+    #[structopt(short, long)]
+    pub debug: bool,
 
-  /// Arguments which will be passed to 'git log'. Note that certain
-  /// options will break the command. Passing file paths/prefixes is
-  /// typical usage.
-  pub git_args: Vec<String>,
+    /// Arguments which will be passed to 'git log'. Note that certain
+    /// options will break the command. Passing file paths/prefixes is
+    /// typical usage.
+    pub git_args: Vec<String>,
 }
 
 /// A friendly conventional commit tool. You probably want the 'commit' subcommand, or 'c' for short.
 #[derive(StructOpt)]
 pub enum Cli {
-  /// Create a new commit
-  Commit(Commit),
+    /// Create a new commit
+    Commit(Commit),
 
-  /// View recent commits
-  Log(Log),
+    /// View recent commits
+    Log(Log),
 }
 
 pub fn parse() -> Cli {
-  let matches = Cli::clap()
-    .setting(AppSettings::TrailingVarArg)
-    .setting(AppSettings::InferSubcommands)
-    .setting(AppSettings::SubcommandRequiredElseHelp)
-    .get_matches();
+    let matches = Cli::clap()
+        .setting(AppSettings::TrailingVarArg)
+        .setting(AppSettings::InferSubcommands)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
+        .get_matches();
 
-  Cli::from_clap(&matches)
+    Cli::from_clap(&matches)
 }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -71,7 +71,7 @@ pub fn log(params: cli::Log, _config: Config) {
                 }),
                 ct::SetFg(ct::Color::Reset),
                 ct::Output(message),
-                ct::Output('\n'.into())
+                ct::Output('\n'.to_string())
             )
             .unwrap();
         }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -38,7 +38,7 @@ pub fn log(params: cli::Log, _config: Config) {
         };
 
         let message = message
-            .split("\n")
+            .split('\n')
             .filter(|s| s.chars().any(|c| !c.is_whitespace()))
             .collect::<Vec<&str>>()
             .join(" ⏎");
@@ -71,7 +71,7 @@ pub fn log(params: cli::Log, _config: Config) {
                 }),
                 ct::SetFg(ct::Color::Reset),
                 ct::Output(message),
-                ct::Output("\n".into())
+                ct::Output('\n'.into())
             )
             .unwrap();
         }

--- a/src/git/parse_log.rs
+++ b/src/git/parse_log.rs
@@ -28,7 +28,7 @@ fn bytes_until_non_ws(s: &str) -> usize {
 impl LogItem {
     /// Parse the message into the components (type, scope, message). Always returns
     /// slices of the original message.
-    pub fn as_conventional<'a>(&'a self) -> Option<Conventional<'a>> {
+    pub fn as_conventional(&self) -> Option<Conventional> {
         let mut ty_pos = None;
         let mut scope_pos = None;
         let mut message_pos = None;
@@ -143,7 +143,7 @@ impl Parser {
             }
             PreMessage { commit, epoch_secs } => {
                 let message = if starts_four_spaces {
-                    let (i, _) = line.char_indices().skip(4).next().unwrap();
+                    let (i, _) = line.char_indices().nth(4).unwrap();
                     liner[i..].to_string()
                 } else {
                     line
@@ -164,7 +164,7 @@ impl Parser {
                 mut files,
             } => {
                 let msg_addition = if starts_four_spaces {
-                    line.char_indices().skip(4).next().map(|(i, _)| &liner[i..])
+                    line.char_indices().nth(4).map(|(i, _)| &liner[i..])
                 } else {
                     None
                 };
@@ -190,7 +190,7 @@ impl Parser {
                         message,
                         files,
                     }
-                } else if line.starts_with(":") {
+                } else if line.starts_with(':') {
                     if let Some(name) = liner.split_whitespace().last() {
                         files.push(name.to_string());
                     }
@@ -221,7 +221,7 @@ impl Parser {
     }
 }
 
-pub fn parse_logs<'a>(lines: impl Iterator<Item = String>) -> Vec<LogItem> {
+pub fn parse_logs(lines: impl Iterator<Item = String>) -> Vec<LogItem> {
     let mut parser = Parser::SeekingHeader;
     let mut items = vec![];
 

--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -1,4 +1,5 @@
 use crossterm as ct;
+use std::cmp::Ordering;
 use std::io::{self, Write as _W};
 
 // If the number of changed lines is larger than this, then
@@ -111,14 +112,16 @@ impl TermBuffer {
     }
 
     fn queue_move_cursor_y(&mut self, down: isize) {
-        if down > 0 {
-            let down = down as u16;
-            ct::queue!(self.stdout, ct::Down(down), ct::Left(1000)).unwrap();
-        } else if down < 0 {
-            let up = (-down) as u16;
-            ct::queue!(self.stdout, ct::Up(up), ct::Left(1000)).unwrap();
-        } else {
-            ct::queue!(self.stdout, ct::Left(1000)).unwrap();
+        match down.cmp(&0) {
+            Ordering::Greater => {
+                let down = down as u16;
+                ct::queue!(self.stdout, ct::Down(down), ct::Left(1000)).unwrap();
+            }
+            Ordering::Less => {
+                let up = (-down) as u16;
+                ct::queue!(self.stdout, ct::Up(up), ct::Left(1000)).unwrap();
+            }
+            _ => ct::queue!(self.stdout, ct::Left(1000)).unwrap(),
         }
     }
 
@@ -167,15 +170,15 @@ impl TermBuffer {
 
         let (cx, cy) = (0, state.len() as u16);
         let (dx, dy) = state.get_cursor();
-        if dy < cy {
-            ct::queue!(self.stdout, ct::Up(cy - dy)).unwrap();
-        } else if dy > cy {
-            ct::queue!(self.stdout, ct::Down(dy - cy)).unwrap();
+        match dy.cmp(&cy) {
+            Ordering::Less => ct::queue!(self.stdout, ct::Up(cy - dy)).unwrap(),
+            Ordering::Greater => ct::queue!(self.stdout, ct::Down(dy - cy)).unwrap(),
+            _ => {}
         }
-        if dx < cx {
-            ct::queue!(self.stdout, ct::Left(cx - dx)).unwrap();
-        } else if dx > cx {
-            ct::queue!(self.stdout, ct::Right(dx - cx)).unwrap();
+        match dx.cmp(&cx) {
+            Ordering::Less => ct::queue!(self.stdout, ct::Left(cx - dx)).unwrap(),
+            Ordering::Greater => ct::queue!(self.stdout, ct::Right(dx - cx)).unwrap(),
+            _ => {}
         }
 
         ct::queue!(self.stdout, crate::color::reset_item()).unwrap();
@@ -265,7 +268,7 @@ impl State {
     }
 
     pub fn reset(&mut self) -> Self {
-        std::mem::replace(self, State::default())
+        std::mem::take(self)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &str> {


### PR DESCRIPTION
First off, let me say I love the tool. This has been my go-to for nearly a year now. I've been wanting to give back for a while now but only just found the time. But, first things first, linting:

### What kind of change does this PR introduce?
Linting/formatting

### Did you add tests for your changes?
Not required.

### Summary
I ran through the app with Fmt and Clippy to fix the low-hanging fruit: Indentation issues, using `&str`s where `char`s would do, `match` in place of `if-else` blocks, etc. No real changes to the app, just initial cleaning to get out of the way.