### PR TITLE
Bugfix: Renamed files

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -29,6 +29,7 @@ pub struct GitStatusItem {
 pub enum GitStatusType {
     Added,
     Modified,
+    Renamed,
     Untracked,
     Deleted,
 }
@@ -246,6 +247,7 @@ impl GitStatusType {
         match ch {
             'A' => Some(GitStatusType::Added),
             'M' => Some(GitStatusType::Modified),
+            'R' => Some(GitStatusType::Renamed),
             'D' => Some(GitStatusType::Deleted),
             '?' => Some(GitStatusType::Untracked),
             _ => None,


### PR DESCRIPTION
### What kind of change does this PR introduce?

Fixing a bug with renamed files

### Did you add tests for your changes?

No

### Summary

When renaming a file (say ReadMe.md -> Readme.md), Git will automatically stage this change with "R" for its status. However, Glint does not pick up on renamed files as staged, and so still takes you to the file selection stage. This introduces a problem. 

Glint picks up on the filename as "ReadMe.md -> Readme.md" from `git status`, and so if you were to select this file and add it to your commit, after completing your message, Glint tries to stage the file `ReadMe.md -> Readme.md`. This does not work, as that is not a valid file. However, because Git already has this change staged, all that ends up happening is that a pathspec error message is shown. The commit still go through even though the `git add` fails. 

While I'm not a fan of skipping the file selection stage, this brings consistency. Renamed files, just like previously staged files, will cause Glint to skip to the `Type` prompt. 