### PR TITLE
Feature: Colored file labels in file prompt

### DIFF
--- a/examples/log-key-event.rs
+++ b/examples/log-key-event.rs
@@ -23,7 +23,7 @@ fn main() {
                     break;
                 }
                 println!("{:?}", ev);
-                ct::cursor().move_left(100);
+                ct::cursor().move_left(100).unwrap();
             }
         }
     })

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,7 +20,7 @@ pub struct GitStatus(pub Vec<GitStatusItem>);
 
 #[derive(Debug, Clone)]
 pub struct GitStatusItem {
-    file: String,
+    file_name: String,
     staged: Option<GitStatusType>,
     unstaged: Option<GitStatusType>,
 }
@@ -196,7 +196,7 @@ impl Git {
                     None
                 } else {
                     Some(GitStatusItem {
-                        file,
+                        file_name: file,
                         staged,
                         unstaged,
                     })
@@ -226,22 +226,18 @@ impl GitStatus {
 }
 
 impl GitStatusItem {
-    pub fn new(file: String) -> Self {
+    pub fn new(file_name: String) -> Self {
         GitStatusItem {
-            file,
+            file_name,
             staged: None,
             unstaged: None,
         }
     }
-    pub fn file(&self) -> &str {
-        &self.file
+    pub fn file_name(&self) -> &str {
+        &self.file_name
     }
     pub fn status(&self) -> &GitStatusType {
-        if self.unstaged.is_some() {
-            self.unstaged.as_ref().unwrap()
-        } else {
-            &GitStatusType::None
-        }
+        self.unstaged.as_ref().unwrap_or(&GitStatusType::None)
     }
 }
 
@@ -253,7 +249,7 @@ impl Into<String> for GitStatusItem {
 
 impl Into<String> for &'_ GitStatusItem {
     fn into(self) -> String {
-        self.file().into()
+        self.file_name().into()
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -32,6 +32,7 @@ pub enum GitStatusType {
     Renamed,
     Untracked,
     Deleted,
+    None,
 }
 
 #[derive(Debug)]
@@ -225,8 +226,22 @@ impl GitStatus {
 }
 
 impl GitStatusItem {
+    pub fn new(file: String) -> Self {
+        GitStatusItem {
+            file,
+            staged: None,
+            unstaged: None,
+        }
+    }
     pub fn file(&self) -> &str {
         &self.file
+    }
+    pub fn status(&self) -> &GitStatusType {
+        if self.unstaged.is_some() {
+            self.unstaged.as_ref().unwrap()
+        } else {
+            &GitStatusType::None
+        }
     }
 }
 

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -138,7 +138,7 @@ impl<'a> FilesPrompt<'a> {
             let default_color = ct::Color::White;
 
             let status_untracked = style('+').with(ct::Color::Rgb { r: 96, g: 218, b: 177 });
-            let status_modified = style('/').with(ct::Color::Rgb { r: 96, g: 112, b: 218 });
+            let status_modified = style('•').with(ct::Color::Rgb { r: 96, g: 112, b: 218 });
             let status_deleted = style('-').with(ct::Color::Rgb { r: 218, g: 96, b: 118 });
             let status_none = style(' ').with(default_color);
 

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -135,7 +135,7 @@ impl<'a> FilesPrompt<'a> {
             let y_offset = buffer.lines() + self.focused_index;
 
             let focused_color = ct::Color::Blue;
-            let default_color = ct::Color::White;
+            let default_color = ct::Color::Reset;
 
             let status_untracked = style('+').with(ct::Color::Rgb { r: 96, g: 218, b: 177 });
             let status_modified = style('•').with(ct::Color::Rgb { r: 96, g: 112, b: 218 });

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -140,7 +140,7 @@ impl<'a> FilesPrompt<'a> {
             let status_untracked = style('+').with(ct::Color::Rgb { r: 96, g: 218, b: 177 });
             let status_modified = style('•').with(ct::Color::Rgb { r: 96, g: 112, b: 218 });
             let status_deleted = style('-').with(ct::Color::Rgb { r: 218, g: 96, b: 118 });
-            let status_none = style(' ').with(default_color);
+            let status_none = style(' ');
 
             // Padded limit (never overflows by 1 item)
             let total = self.options.len();

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -9,7 +9,7 @@ use std::iter;
 pub struct FilesPrompt<'a> {
     config: &'a Config,
     checked: Vec<bool>,
-    selected_index: u16,
+    highlighted_index: u16,
     options: GitStatus,
     git: &'a Git,
 }
@@ -25,7 +25,7 @@ impl<'a> FilesPrompt<'a> {
         FilesPrompt {
             config,
             checked: (0..options.len()).map(|_| false).collect(),
-            selected_index: 0,
+            highlighted_index: 0,
             options,
             git,
         }
@@ -59,7 +59,7 @@ impl<'a> FilesPrompt<'a> {
                     return FilesPromptResult::Terminate;
                 }
                 Some(InputEvent::Keyboard(KeyEvent::Char(' '))) => {
-                    let index = self.selected_index as usize;
+                    let index = self.highlighted_index as usize;
                     if index == 0 {
                         let set_to = !self.checked.iter().all(|&x| x);
 
@@ -71,7 +71,7 @@ impl<'a> FilesPrompt<'a> {
                     }
                 }
                 Some(InputEvent::Keyboard(KeyEvent::Char('d'))) => {
-                    let index = self.selected_index as usize;
+                    let index = self.highlighted_index as usize;
                     let files = if index == 0 {
                         vec![]
                     } else {
@@ -100,7 +100,7 @@ impl<'a> FilesPrompt<'a> {
                     return FilesPromptResult::Escape;
                 }
                 Some(InputEvent::Keyboard(KeyEvent::Up)) => {
-                    self.selected_index = match self.selected_index {
+                    self.highlighted_index = match self.highlighted_index {
                         0 => 0,
                         x => x.saturating_sub(1),
                     };
@@ -108,9 +108,9 @@ impl<'a> FilesPrompt<'a> {
                 Some(InputEvent::Keyboard(KeyEvent::Down)) => {
                     let total = self.options.len() as u16 + 1;
 
-                    self.selected_index += 1;
-                    if self.selected_index >= total {
-                        self.selected_index = total.saturating_sub(1);
+                    self.highlighted_index += 1;
+                    if self.highlighted_index >= total {
+                        self.highlighted_index = total.saturating_sub(1);
                     }
                 }
                 None => {}
@@ -132,9 +132,9 @@ impl<'a> FilesPrompt<'a> {
             buffer.push_line(prompt_pre);
             buffer.push_line(format!("{}{}", underscores, reset_display()));
 
-            let y_offset = buffer.lines() + self.selected_index;
+            let y_offset = buffer.lines() + self.highlighted_index;
 
-            let selected_color = style("").with(ct::Color::Blue).to_string();
+            let highlighted_color = style("").with(ct::Color::Blue).to_string();
 
             // Padded limit (never overflows by 1 item)
             let total = self.options.len();
@@ -146,8 +146,8 @@ impl<'a> FilesPrompt<'a> {
                 .enumerate()
                 .take(take + 1)
             {
-                let color = if i as u16 == self.selected_index {
-                    &selected_color as &str
+                let color = if i as u16 == self.highlighted_index {
+                    &highlighted_color as &str
                 } else {
                     ""
                 };


### PR DESCRIPTION
### What kind of change does this PR introduce?
A feature

### Did you add tests for your changes?
No

### Summary
I sometimes find it a bit difficult to use glint when I have a lot of files changed and no visual indication to give me an idea of the type of change. For example, if you were to rename a file and then run `git reset`, you'll have two files in your list; one to be deleted, and one to be added. This sometimes makes things a bit hard to keep track of.

What I propose is the color-coding of file names in the file prompt based on their GitStatusType. That way, it's clear what is a new file, what is a removed file, and what is a modified file.

This is just a draft, and I'm certainly not married to the colors (the modified color in particular I'm not happy with) but I'm curious to hear your thoughts, if you have any. 