### PR TITLE
refactor: Stop progression from file prompt if nothing selected

### DIFF
--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -97,14 +97,16 @@ impl<'a> FilesPrompt<'a> {
                     }
                 }
                 Some((KeyCode::Enter, _, _, _)) => {
-                    let selected = self
+                    let selected: Vec<String> = self
                         .options
                         .iter()
                         .enumerate()
                         .filter_map(|(i, file)| Some(file).filter(|_| self.checked[i]))
                         .map(Into::into)
                         .collect();
-                    return FilesPromptResult::Files(selected);
+                    if !selected.is_empty() {
+                        return FilesPromptResult::Files(selected);
+                    }
                 }
 
                 Some((KeyCode::Esc, _, _, _)) => {


### PR DESCRIPTION
### What kind of change does this PR introduce?
A fix to existing behavior

### Did you add tests for your changes?
No

### Summary
Every now and then I accidentally toggle an item twice in the files prompt which means no files are staged. However, Glint does not warn me of this. Instead, I'm only told that no changes were commited after I've typed up my commit message.

This PR fixes the behavior. When a user presses the `enter` key on the file prompt, if there are no selected files, the user will not progress to the next prompt. 

Closes #9 