### PR TITLE
fix: Correcting types overflow + spacing inconsistency

### DIFF
--- a/src/prompt/type_prompt.rs
+++ b/src/prompt/type_prompt.rs
@@ -100,7 +100,12 @@ impl<'a> TypePrompt<'a> {
                     self.focused_index = self.focused_index.saturating_sub(1);
                 }
                 Some((KeyCode::Down, false, _, false)) => {
+                    let total = self.config.types.len() as u16;
+
                     self.focused_index += 1;
+                    if self.focused_index >= total {
+                        self.focused_index = total.saturating_sub(1);
+                    }
                 }
                 None => {}
                 _ => continue,
@@ -116,7 +121,7 @@ impl<'a> TypePrompt<'a> {
                 style(s).with(Color::Magenta).to_string()
             });
 
-            let y_offset = header.len() as u16;
+            let y_offset = header.len() as u16 + 1;
 
             for line in header {
                 buffer.push_line(line);
@@ -126,6 +131,7 @@ impl<'a> TypePrompt<'a> {
                 let prompt_pre = "Choose a type: ";
                 let prompt_post = &self.input;
                 let underscores = "_".repeat(6 - self.input.len());
+                buffer.push_line("");
                 buffer.push_line(format!(
                     "{}{}{}{}",
                     prompt_pre,


### PR DESCRIPTION
### What kind of change does this PR introduce?
A fix to existing behavior

### Did you add tests for your changes?
No

### Summary
This PR fixes an issue and an inconsistency.

The issue is that, on the types prompt, there is no bottom bound for the cursor. There's 13 types by default, but the cursor could go to index 100 if it so pleased. There is no cap. This PR introduces a bottom bound for the cursor by reusing the same logic you used for the bottom bound on the files prompt. 

The inconsistency is one with spacing. On the files prompt, you have:

```
<glint>

Toggle files....
```

but on the types prompt:

```
<glint>
Choose a type....
```

This PR adds a blank line to keep consistency. This will become more important when a fix is found for issue #11. Because of it, you can't easily tell that there is a lack of spacing, but once that is consistent this would've been more noticeable.  