### PR TITLE
WIP: Fix/blank line on buffer reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 **/*.rs.bk
 .vscode
+.idea
 release-files

--- a/src/git.rs
+++ b/src/git.rs
@@ -192,10 +192,7 @@ impl Git {
                 let staged = chars
                     .next()
                     .and_then(GitStatusType::from_char)
-                    .filter(|item| match item {
-                        GitStatusType::Untracked => false,
-                        _ => true,
-                    });
+                    .filter(|item| !matches!(item, GitStatusType::Untracked));
                 let unstaged = chars.next().and_then(GitStatusType::from_char);
 
                 chars.next();

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -181,7 +181,7 @@ impl<'a> FilesPrompt<'a> {
             let take = if total > max { max - 3 } else { total };
 
             for (i, git_status_item) in iter::once(&GitStatusItem::new("<all>".to_owned()))
-                .chain(self.options.iter().map(|item| item))
+                .chain(self.options.iter())
                 .enumerate()
                 .take(take + 1)
             {

--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -157,9 +157,9 @@ impl TermBuffer {
     }
 
     /// Renders a complete frame to the terminal
-    pub fn render_full(&mut self, content_changed: bool) {
-        self.cursor_to_start(content_changed);
-        self.queue_clear(content_changed);
+    pub fn render_full(&mut self, content_changed_length: bool) {
+        self.cursor_to_start(content_changed_length);
+        self.queue_clear(content_changed_length);
 
         let state = self.state.reset();
 
@@ -215,24 +215,23 @@ impl TermBuffer {
     }
 
     /// Clears from the cursor position down
-    fn queue_clear(&mut self, content_changed: bool) {
+    fn queue_clear(&mut self, content_changed_length: bool) {
         ct::queue!(self.stdout, Clear(ClearType::FromCursorDown)).unwrap();
-        if !content_changed {
-            ct::queue!(self.stdout, Clear(ClearType::CurrentLine)).unwrap();
+        if content_changed_length {
+            ct::queue!(self.stdout, MoveLeft(1000)).unwrap();
         }
-        ct::queue!(self.stdout, MoveLeft(1000)).unwrap();
     }
 
-    fn cursor_to_start(&mut self, content_changed: bool) {
+    fn cursor_to_start(&mut self, content_changed_length: bool) {
         let (_, y) = self.flushed.cursor;
 
         if y > 0 {
-            if !content_changed {
-                ct::queue!(self.stdout, MoveLeft(1000)).unwrap();
-                ct::queue!(self.stdout, MoveUp(y)).unwrap();
-            } else {
-                ct::queue!(self.stdout, MoveRight(1000)).unwrap();
+            if content_changed_length {
                 ct::queue!(self.stdout, MoveUp(y + 1)).unwrap();
+                ct::queue!(self.stdout, MoveRight(1000)).unwrap();
+            } else {
+                ct::queue!(self.stdout, MoveUp(y)).unwrap();
+                ct::queue!(self.stdout, MoveLeft(1000)).unwrap();
             }
         }
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?
A fix to a bug

### Did you add tests for your changes?
No

### Summary
Bug outlined in #11. Best way to show it off is with a gif.

![94774140-dd65cc00-0382-11eb-94bd-f4a89bbb79d4](https://user-images.githubusercontent.com/33403762/95805398-edf33c00-0cca-11eb-9736-c939267bd2af.gif)

I still have two known problem areas:
* Going backwards from the commit message prompt to the scope prompt
* Using the search functionality for the type prompt

Currently a messy hack, still trying to wrap my head around what exactly is going on with the cursor and content lengths. Behavior is odd to say the least.