### PR TITLE
fix: Correcting bug stemming from not disabling raw mode

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -17,6 +17,11 @@ fn with_raw<R>(f: impl FnOnce() -> R) -> R {
     result
 }
 
+fn exit<R>(code: i32) -> Option<R> {
+    let _r = terminal::disable_raw_mode();
+    std::process::exit(code)
+}
+
 pub fn commit(params: cli::Commit, config: Config) {
     let git = match Git::from_cwd() {
         Ok(git) => git,
@@ -63,8 +68,8 @@ pub fn commit(params: cli::Commit, config: Config) {
                     match prompt::FilesPrompt::new(&config, &git, git_status.clone().unwrap()).run()
                     {
                         prompt::FilesPromptResult::Files(files) => Some(files),
-                        prompt::FilesPromptResult::Terminate => std::process::exit(2),
-                        prompt::FilesPromptResult::Escape => std::process::exit(0),
+                        prompt::FilesPromptResult::Terminate => exit(2),
+                        prompt::FilesPromptResult::Escape => exit(0),
                     }
                 });
 
@@ -75,7 +80,7 @@ pub fn commit(params: cli::Commit, config: Config) {
                     Some(ref ty) => Some(ty.to_string()),
                     None => with_raw(|| match prompt::TypePrompt::new(&config).run() {
                         prompt::TypePromptResult::Type(ty) => Some(ty),
-                        prompt::TypePromptResult::Terminate => std::process::exit(2),
+                        prompt::TypePromptResult::Terminate => exit(2),
                         prompt::TypePromptResult::Escape => None,
                     }),
                 };
@@ -95,7 +100,7 @@ pub fn commit(params: cli::Commit, config: Config) {
                     Some(ref scope) => Some((Some(scope.to_string()), 0)),
                     None => with_raw(|| match prompt::ScopePrompt::new(&config, &ty).run() {
                         prompt::ScopePromptResult::Scope(scope, lines) => Some((scope, lines)),
-                        prompt::ScopePromptResult::Terminate => std::process::exit(2),
+                        prompt::ScopePromptResult::Terminate => exit(2),
                         prompt::ScopePromptResult::Escape => None,
                     }),
                 };
@@ -116,7 +121,7 @@ pub fn commit(params: cli::Commit, config: Config) {
                     Some(ref message) => Some(message.to_string()),
                     None => with_raw(|| match prompt::MessagePrompt::new(&config).run() {
                         prompt::MessagePromptResult::Message(message) => Some(message),
-                        prompt::MessagePromptResult::Terminate => std::process::exit(2),
+                        prompt::MessagePromptResult::Terminate => exit(2),
                         prompt::MessagePromptResult::Escape => None,
                     }),
                 };


### PR DESCRIPTION
### What kind of change does this PR introduce?
A fix to a bug when exiting process

### Did you add tests for your changes?
No

### Summary
Bug stems from #13.

Unfortunately I did not catch that exiting from within `with_raw()` would keep the user's terminal stuck in raw mode. This gives quite egregious terminal output (attached image shows a `cargo build` operation in a project with a few linter warnings as an example) which is definitely a negative to the UX.

To fix this I simply created a new function that would always ensure raw mode was disabled before exiting with what ever process code is desired.

Sorry for this, I should've caught it.

![temp](https://user-images.githubusercontent.com/33403762/95719014-de291880-0c34-11eb-8672-d1066ecadc09.png)