### PR TITLE
Fix: Type search field overflow

### DIFF
--- a/src/prompt/type_prompt.rs
+++ b/src/prompt/type_prompt.rs
@@ -88,7 +88,9 @@ impl<'a> TypePrompt<'a> {
                     return TypePromptResult::Type(self.get_at_selected_index().to_string());
                 }
                 Some((KeyCode::Char(c), false, _, false)) => {
-                    self.input.push(c.to_ascii_lowercase());
+                    if self.input.len() < 6 {
+                        self.input.push(c.to_ascii_lowercase());
+                    }
                 }
                 Some((KeyCode::Backspace, false, _, false)) => {
                     self.input.pop();
@@ -121,11 +123,11 @@ impl<'a> TypePrompt<'a> {
                 style(s).with(Color::Magenta).to_string()
             });
 
-            let y_offset = header.len() as u16 + 1;
-
             for line in header {
                 buffer.push_line(line);
             }
+
+            let y_offset = buffer.lines() + 1;
 
             let after_prompt_x = {
                 let prompt_pre = "Choose a type: ";

--- a/src/prompt/type_prompt.rs
+++ b/src/prompt/type_prompt.rs
@@ -88,9 +88,7 @@ impl<'a> TypePrompt<'a> {
                     return TypePromptResult::Type(self.get_at_selected_index().to_string());
                 }
                 Some((KeyCode::Char(c), false, _, false)) => {
-                    if self.input.len() < 6 {
-                        self.input.push(c.to_ascii_lowercase());
-                    }
+                    self.input.push(c.to_ascii_lowercase());
                 }
                 Some((KeyCode::Backspace, false, _, false)) => {
                     self.input.pop();
@@ -132,7 +130,7 @@ impl<'a> TypePrompt<'a> {
             let after_prompt_x = {
                 let prompt_pre = "Choose a type: ";
                 let prompt_post = &self.input;
-                let underscores = "_".repeat(6 - self.input.len());
+                let underscores = "_".repeat(6_usize.saturating_sub(self.input.len()));
                 buffer.push_line("");
                 buffer.push_line(format!(
                     "{}{}{}{}",


### PR DESCRIPTION
### What kind of change does this PR introduce?
A fix to a bug

### Did you add tests for your changes?
No

### Summary
The input length for the types search field in the types prompt was not ever checked. So the following, when `.len()` returned 7+, was quite insane. 

```
let underscores = "_".repeat(6 - self.input.len());
```

Quite frankly I'm in awe of the output. Unless I've copy pasted incorrectly, Rust is trying to allocate 18,446 Petabytes worth of underscores. *Nice*

![temp](https://user-images.githubusercontent.com/33403762/95828192-48f05780-0cfa-11eb-9842-019543140584.png)

Of course this breaks terminal formatting as well as it's a hard crash of the program from within the `.with_raw()`. I have to hope that output number is some sort of UI glitch or I really have to ask the Rust team why that's not capped lower.

Edit: Ah, didn't realize `.repeat()` took a `u64` of all things. Thought it would be much more limited than that.  