### PR TITLE
Correctly erase all prompts on escape

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -134,7 +134,7 @@ pub fn commit(params: cli::Commit, config: Config) {
                         let mut stderr = std::io::stderr();
                         ct::queue!(
                             stderr,
-                            cursor::MoveUp(escape_clear_lines + 2),
+                            cursor::MoveUp(escape_clear_lines),
                             terminal::Clear(terminal::ClearType::FromCursorDown)
                         )
                         .unwrap();

--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -38,7 +38,7 @@ impl Drop for TermBuffer {
         }
         self.cursor_to_end();
 
-        ct::queue!(self.stdout, Print("\n".to_string())).unwrap();
+        ct::queue!(self.stdout, Print("".to_string())).unwrap();
         self.flush();
     }
 }
@@ -153,7 +153,8 @@ impl TermBuffer {
         if dx > 0 {
             ct::queue!(self.stdout, MoveRight(dx)).unwrap();
         }
-        self.flushed.cursor = (0, dy);
+
+        self.flushed.cursor = (dx, dy);
     }
 
     /// Renders a complete frame to the terminal


### PR DESCRIPTION
Resolves the same issue as https://github.com/brigand/glint/pull/14 

Now every path forward and backwards through prompts appears to work perfectly for me.