### PR TITLE
fix: No longer flashes when cursor does not move position

### DIFF
--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -108,16 +108,21 @@ impl TermBuffer {
 
         let changed_cursor = self.state.cursor != self.flushed.cursor;
 
-        if !changed_lines.is_empty() && changed_lines.len() <= MAX_PATCH_LINES {
+        if changed_lines.is_empty() && !changed_cursor {
+            self.flushed = self.state.reset();
+        } else if changed_lines.is_empty() && changed_cursor {
+            match self.state.cursor.1 == self.flushed.cursor.1 {
+                true => self.render_one_line(self.state.cursor.1 as usize),
+                false => {
+                    self.render_one_line(self.flushed.cursor.1 as usize);
+                    self.render_one_line(self.state.cursor.1 as usize);
+                }
+            }
+            self.flushed = self.state.reset();
+        } else if !changed_lines.is_empty() && changed_lines.len() <= MAX_PATCH_LINES {
             for line_num in changed_lines {
                 self.render_one_line(line_num);
             }
-            self.flushed = self.state.reset();
-        } else if changed_cursor {
-            self.render_one_line(self.flushed.cursor.1 as usize);
-            self.render_one_line(self.state.cursor.1 as usize);
-            self.flushed = self.state.reset();
-        } else if changed_lines.is_empty() {
             self.flushed = self.state.reset();
         } else {
             self.render_full();

--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -111,6 +111,8 @@ impl TermBuffer {
                 self.render_one_line(line_num);
             }
             self.flushed = self.state.reset();
+        } else if changed_lines.is_empty() {
+            self.flushed = self.state.reset();
         } else {
             self.render_full();
         }

--- a/src/term_buffer.rs
+++ b/src/term_buffer.rs
@@ -106,10 +106,16 @@ impl TermBuffer {
             .filter_map(|(i, (a, b))| if a == b { None } else { Some(i) })
             .collect();
 
+        let changed_cursor = self.state.cursor != self.flushed.cursor;
+
         if !changed_lines.is_empty() && changed_lines.len() <= MAX_PATCH_LINES {
             for line_num in changed_lines {
                 self.render_one_line(line_num);
             }
+            self.flushed = self.state.reset();
+        } else if changed_cursor {
+            self.render_one_line(self.flushed.cursor.1 as usize);
+            self.render_one_line(self.state.cursor.1 as usize);
             self.flushed = self.state.reset();
         } else if changed_lines.is_empty() {
             self.flushed = self.state.reset();


### PR DESCRIPTION
Still using the tool, still really loving it.

This fixes a bug that causes a flash when the content of the frame does not change. 

The basic reproduction is moving the cursor against the bounds, like "up" on the file prompt. Because the bounds were protected with `saturating_sub`, the frame would have no changed lines, but the logic dictated that `render_full()` was required which would causes a flash of content. 

Super simple fix. 

https://user-images.githubusercontent.com/33403762/109256466-aa055d00-77bb-11eb-8ed5-aecb4f09f778.mp4

Edit: ~~Oops, this breaks left cursor (and only left cursor) on the message prompt. Need to get that fixed first.~~
Edit 2: ~~Need to come back in the morning, but the remaining issue is the scope prompt gets a bit messed up when going onto the message stage. Probably also need to move around the render logic. I think what's there now *works* but it definitely doesn't following a logical flow.~~