### PR TITLE
fix: New directory will no longer attempt to open in `less`

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -249,6 +249,10 @@ impl GitStatusItem {
         self.unstaged.as_ref().unwrap_or(&GitStatusType::None)
     }
 
+    pub fn is_dir(&self) -> bool {
+        self.file_name.ends_with('/')
+    }
+
     pub fn is_new(&self) -> bool {
         self.staged.is_none() && matches!(self.unstaged, Some(GitStatusType::Untracked))
     }

--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -105,7 +105,7 @@ impl<'a> FilesPrompt<'a> {
                             .nth(index - 1)
                             .expect("diff should match a file");
 
-                        if option.is_new() {
+                        if option.is_new() && !option.is_dir() {
                             let _r = self.git.less(option.file_name());
                         } else {
                             let files = vec![option.file_name().to_string()];


### PR DESCRIPTION
If a new directory was created and a user pressed the d key on the status item, `less()` could not open to show the diff and the output would become a bit messed up. See first video.

To fix this, I just added a check to see if the status item is a directory. If it is, it's passed to `diff_less()` which handles it a bit better.

Still probably not great, as the diff there is useless, but it matches what would happen if the user tried to diff `<all>` with this setup. Could disable diffing directories altogether, maybe with a note popping up inline? Or diff each child file in that directory. Not sure. But either option takes more effort than this quick fix. 

As-is

https://user-images.githubusercontent.com/33403762/120242688-20868080-c22b-11eb-943b-d34972a37587.mp4

Fix

https://user-images.githubusercontent.com/33403762/120242692-24b29e00-c22b-11eb-8b81-ce0a243566ee.mp4

