### PR TITLE
feat: Adding 'q' as Esc alias on files prompt

### DIFF
--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -69,6 +69,7 @@ impl<'a> FilesPrompt<'a> {
                 // The right arrow strokes are also aliased to the diff shortcut, since
                 // it's like going deeper into the tree
                 *key = match key {
+                    KeyCode::Char('q') => KeyCode::Esc,
                     KeyCode::Char('k') => KeyCode::Up,
                     KeyCode::Char('j') => KeyCode::Down,
                     KeyCode::Char('l') | KeyCode::Right => KeyCode::Char('d'),


### PR DESCRIPTION
Not sure if this is of any interest, but thought to open a PR as I was adding it for myself.

I often run into the situation where I'll open a diff with Glint, only to remember something, and want to exit. The correct combination would be `q` to exit less, then `esc` to exit Glint. I'd be lying if I said I didn't screw up the order ~50% of the time however. 

This simply adds `q` as an alias for `esc` on the files prompt. If you open a diff, it's easy to use `qq` to exit out of Glint entirely. 