### PR TITLE
feat: diff on untracked directory prints untracked files in `less`

### DIFF
--- a/src/prompt/files_prompt.rs
+++ b/src/prompt/files_prompt.rs
@@ -106,8 +106,14 @@ impl<'a> FilesPrompt<'a> {
                             .nth(index - 1)
                             .expect("diff should match a file");
 
-                        if option.is_new() && !option.is_dir() {
-                            let _r = self.git.less(option.file_name());
+                        if option.is_new() {
+                            if option.is_dir() {
+                                let _r = self
+                                    .git
+                                    .directory_untracked_less(option.file_name().as_ref());
+                            } else {
+                                let _r = self.git.less(option.file_name());
+                            }
                         } else {
                             let files = vec![option.file_name().to_string()];
                             let _r = self.git.diff_less(files);


### PR DESCRIPTION
When pressing 'd' on an untracked directory in the files prompt, it will now show untracked files within that directory, according to `git ls-files`.

Ref: https://github.com/brigand/glint/pull/21#issuecomment-851699926

![diff output for untracked directory](https://user-images.githubusercontent.com/936069/120551329-c01e4d00-c3aa-11eb-8cc0-88b7ec906521.png)
